### PR TITLE
make AppImage with sharun, build on archlinux, add `aarch64` releases, use debloated packages, use uruntime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,64 +1,103 @@
-name: Release
+name: Appimage
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
-  push:
-    tags:
-      - 'v*'
+  schedule:
+    - cron: "0 7 1/14 * *"
+  workflow_dispatch:
 
 jobs:
-  build-stable:
-    runs-on: ubuntu-24.04
+  build:
+    runs-on: ubuntu-latest
+    container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
-      - uses: actions/checkout@v4
-      - name: Set env
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
-      - name: Extract major version
-        run: echo "MAJOR_VERSION=v${GITHUB_REF#refs/tags/v}" | cut -d '.' -f 1 >> $GITHUB_ENV
+    - uses: actions/checkout@v3
 
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get upgrade -y
-          sudo apt-get install -y build-essential cmake pkg-config curl git clang ninja-build ccache
-          sudo apt-get install -y libgtk-3-dev libcanberra-gtk-module libgl-dev libasound2-dev libao-dev libopenal-dev libsdl2-dev libpulse-dev libudev-dev
-          sudo apt-get install -y wget file gpg appstream pkgconf
+    - name: Get dependencies
+      if: always()
+      run: |
+        chmod +x ./get-dependencies.sh && ./get-dependencies.sh
 
-      - name: Install librashader
-        run: |
-          echo 'deb http://download.opensuse.org/repositories/home:/chyyran:/librashader/xUbuntu_24.04/ /' | sudo tee /etc/apt/sources.list.d/home:chyyran:librashader.list
-          curl -fsSL https://download.opensuse.org/repositories/home:chyyran:librashader/xUbuntu_24.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home_chyyran_librashader.gpg > /dev/null
-          sudo apt-get update
-          sudo apt-get install -y librashader
+    - name: Make AppImage
+      run: |
+        chmod +x ./ares-appimage.sh && ./ares-appimage.sh
+        mkdir dist
+        mv *.AppImage* dist/
 
-      - name: Build ares
-        run: |
-          git clone -b $MAJOR_VERSION https://github.com/ares-emulator/ares
-          cd ares
-          mkdir -p AppDir/usr
-          mkdir build && cd build
-          cmake .. -G Ninja
-          cmake --build . -j$(nproc)
-          cmake --install . --strip --prefix ../AppDir/usr
+    - name: Check version file
+      run: |
+       cat ~/version
+       echo "APP_VERSION=$(cat ~/version)" >> "${GITHUB_ENV}"
+    
+    - name: Upload artifact
+      uses: actions/upload-artifact@v4.4.3
+      with:
+        name: AppImage
+        path: 'dist'
+        
+    - name: Upload version file
+      uses: actions/upload-artifact@v4.4.3
+      with:
+       name: version
+       path: ~/version
+    
+  release:
+      needs: [build]
+      permissions: write-all
+      runs-on: ubuntu-latest
 
-      - name: Build appimage
-        run: |
-          export LINUXDEPLOY_OUTPUT_VERSION="${MAJOR_VERSION}"
-          export APPIMAGE_EXTRACT_AND_RUN=1
-          export LD_LIBRARY_PATH=AppDir/usr/lib
-          export DEPLOY_GTK_VERSION=3
-          cd ares
-          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage
-          wget https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh
-          chmod +x linuxdeploy-plugin-gtk.sh linuxdeploy-x86_64.AppImage
-          mkdir -p AppDir/usr/share/metainfo
-          cp ../net.ares.emu.appdata.xml AppDir/usr/share/metainfo/
-          cp desktop-ui/resource/ares.desktop desktop-ui/resource/net.ares.emu.desktop
-          ./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin gtk --output appimage --desktop-file desktop-ui/resource/net.ares.emu.desktop --icon-file desktop-ui/resource/ares.png --library /usr/lib/x86_64-linux-gnu/librashader.so
+      steps:
+        - uses: actions/download-artifact@v4.1.8
+          with:
+            name: AppImage
+        - uses: actions/download-artifact@v4.1.8
+          with:
+            name: version
 
-      - name: release
-        uses: "marvinpinto/action-automatic-releases@latest"
-        with:
-          prerelease: false
-          draft: true
-          files: /home/runner/work/ares-emu-appimage/ares-emu-appimage/ares/ares*.AppImage*
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
+        - name: Read version
+          run: |
+            cat version
+            export VERSION="$(cat version)"
+            echo "APP_VERSION=${VERSION}" >> "${GITHUB_ENV}"
+    
+        #Version Release
+        - name: Del Previous Release
+          run: |
+            gh release delete "${APP_VERSION}" --repo "${GITHUB_REPOSITORY}" --cleanup-tag  -y
+            sleep 5
+          env:
+            GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          continue-on-error: true
+        - name: Continuous Releaser
+          uses: softprops/action-gh-release@v2
+          with:
+            name: "DeSmuME AppImage ${{ env.APP_VERSION }}"
+            tag_name: "${{ env.APP_VERSION }}"
+            prerelease: false
+            draft: false
+            generate_release_notes: false
+            make_latest: true
+            files: |
+              *.AppImage*
+          continue-on-error: false
+
+        #Snapshot Release
+        - name: Get Date
+          run: |
+            SNAPSHOT_TAG="$(date --utc +'%Y%m%d-%H%M%S')"
+            echo SNAPSHOT_TAG="${SNAPSHOT_TAG}" >> "${GITHUB_ENV}"
+          continue-on-error: false
+        - name: Snapshot Releaser
+          uses: softprops/action-gh-release@v2
+          with:
+            name: "Snapshot ${{ env.APP_VERSION }}"
+            tag_name: "${{ env.SNAPSHOT_TAG }}"
+            prerelease: false
+            draft: false
+            generate_release_notes: false
+            make_latest: false
+            files: |
+              *.AppImage*
+          continue-on-error: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         mv *.AppImage* dist/
 
     - name: Check version file
-      if: ${{ matrix.arch == x86_64 }}
+      if: ${{ matrix.arch == 'x86_64' }}
       run: |
        cat ~/version
        echo "APP_VERSION=$(cat ~/version)" >> "${GITHUB_ENV}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,17 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    name: "${{ matrix.name }} (${{ matrix.arch }})"
+    runs-on: ${{ matrix.runs-on }}
+    strategy:
+      matrix:
+        include:
+          - runs-on: ubuntu-latest
+            name: "ares build x86_64"
+            arch: x86_64
+          - runs-on: ubuntu-24.04-arm
+            name: "ares build aarch64"
+            arch: aarch64
     container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:
     - uses: actions/checkout@v3
@@ -27,6 +37,7 @@ jobs:
         mv *.AppImage* dist/
 
     - name: Check version file
+      if: ${{ matrix.arch == x86_64 }}
       run: |
        cat ~/version
        echo "APP_VERSION=$(cat ~/version)" >> "${GITHUB_ENV}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Upload artifact
       uses: actions/upload-artifact@v4.4.3
       with:
-        name: AppImage
+        name: AppImage-${{ matrix.arch }}
         path: 'dist'
         
     - name: Upload version file
@@ -53,6 +53,7 @@ jobs:
       with:
        name: version
        path: ~/version
+       overwrite: true
     
   release:
       needs: [build]
@@ -60,10 +61,15 @@ jobs:
       runs-on: ubuntu-latest
 
       steps:
-        - uses: actions/download-artifact@v4.1.8
+        - uses: actions/download-artifact@v4.1.9
           with:
-            name: AppImage
-        - uses: actions/download-artifact@v4.1.8
+            name: AppImage-x86_64
+
+        - uses: actions/download-artifact@v4.1.9
+          with:
+            name: AppImage-aarch64
+
+        - uses: actions/download-artifact@v4.1.9
           with:
             name: version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-latest
-            name: "ares build x86_64"
+            name: "ares build"
             arch: x86_64
           - runs-on: ubuntu-24.04-arm
-            name: "ares build aarch64"
+            name: "ares build"
             arch: aarch64
     container: ghcr.io/pkgforge-dev/archlinux:latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
         - name: Continuous Releaser
           uses: softprops/action-gh-release@v2
           with:
-            name: "DeSmuME AppImage ${{ env.APP_VERSION }}"
+            name: "ares AppImage ${{ env.APP_VERSION }}"
             tag_name: "${{ env.APP_VERSION }}"
             prerelease: false
             draft: false

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -7,14 +7,19 @@ export ARCH="$(uname -m)"
 
 REPO="https://github.com/ares-emulator/ares"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
+GRON="https://raw.githubusercontent.com/xonixx/gron.awk/refs/heads/main/gron.awk"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 
 # BUILD ARES
-git clone "$REPO" ./ares && (
+wget "$GRON" -O ./gron.awk
+chmod +x ./gron.awk
+VERSION=$(wget https://api.github.com/repos/ares-emulator/ares/tags -O - \
+	| ./gron.awk | awk -F'=|"' '/name/ {print $3; exit}')
+echo "$VERSION" > ~/version
+
+git clone --branch "$VERSION" --single-branch "$REPO" ./ares && (
 	cd ./ares
-	VERSION="$(git rev-parse --short HEAD)"
-	echo "$VERSION" > ~/version
 
 	# backport fix from aur package
 	sed -i \
@@ -33,7 +38,6 @@ git clone "$REPO" ./ares && (
 	cmake --install .
 )
 rm -rf ./ares
-VERSION="$(cat ~/version)"
 
 # NOW MAKE APPIMAGE
 mkdir ./AppDir

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -1,0 +1,83 @@
+#!/bin/sh
+
+set -eux
+
+export APPIMAGE_EXTRACT_AND_RUN=1
+export ARCH="$(uname -m)"
+
+REPO="https://github.com/ares-emulator/ares"
+LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
+URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
+UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
+VERSION=test
+
+# BUILD ARES
+git clone "$REPO" ./ares && (
+	cd ./ares
+
+	# backport fix from aur package
+	sed -i \
+	  "s/virtual auto saveName() -> string { return pak->attribute(\"name\"); }/virtual auto saveName() -> string { return name(); }/g" \
+	  ./mia/pak/pak.hpp
+
+	mkdir ./build
+	cd ./build
+	cmake .. -G Ninja \
+		-W no-dev \
+		-D CMAKE_BUILD_TYPE=MinSizeRel \
+		-D CMAKE_INSTALL_PREFIX="/usr" \
+		-D ARES_SKIP_DEPS=ON \
+		--fresh
+	cmake --build . -j"$(nproc)"
+	cmake --install .
+)
+rm -rf ./ares
+
+# NOW MAKE APPIMAGE
+mkdir ./AppDir
+cd ./AppDir
+
+wget --retry-connrefused --tries=30 "$LIB4BN" -O ./lib4bin
+chmod +x ./lib4bin
+xvfb-run -a -- ./lib4bin -p -v -e -s -k \
+	/usr/bin/ares \
+	/usr/bin/sourcery \
+	/usr/lib/libGLX* \
+	/usr/lib/libGL.so* \
+	/usr/lib/libXss.so* \
+	/usr/lib/gio/modules/* \
+	/usr/lib/gdk-pixbuf-*/*/*/* \
+	/usr/lib/alsa-lib/* \
+	/usr/lib/pulseaudio/* \
+	/usr/lib/pipewire-0.3/* \
+	/usr/lib/spa-0.2/*/*
+
+cp -rv /usr/share/ares                                ./share
+cp -v /usr/share/applications/ares.desktop            ./ares.desktop
+cp -v /usr/share/icons/hicolor/256x256/apps/ares.png  ./ares.png
+ln -s ./ares.png ./.DirIcon
+
+# Prepare sharun
+ln ./sharun ./AppRun
+./sharun -g
+
+# turn appdir into appimage
+cd ..
+wget -q "$URUNTIME" -O ./uruntime
+chmod +x ./uruntime
+
+#Add udpate info to runtime
+echo "Adding update information \"$UPINFO\" to runtime..."
+./uruntime --appimage-addupdinfo "$UPINFO"
+
+echo "Generating AppImage..."
+./uruntime --appimage-mkdwarfs -f \
+	--set-owner 0 --set-group 0 \
+	--no-history --no-create-timestamp \
+	--compression zstd:level=22 -S26 -B8 \
+	--header uruntime \
+	-i ./AppDir -o Citron-"$VERSION"-anylinux-"$ARCH".AppImage
+
+echo "Generating zsync file..."
+zsyncmake *.AppImage -u *.AppImage
+echo "All Done!"

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -25,7 +25,7 @@ git clone "$REPO" ./ares && (
 	cd ./build
 	cmake .. -G Ninja \
 		-W no-dev \
-		-D CMAKE_BUILD_TYPE=MinSizeRel \
+		-D CMAKE_BUILD_TYPE=Release \
 		-D CMAKE_INSTALL_PREFIX="/usr" \
 		-D ARES_SKIP_DEPS=ON \
 		--fresh

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -47,6 +47,7 @@ xvfb-run -a -- ./lib4bin -p -v -e -s -k \
 	/usr/lib/libGLX* \
 	/usr/lib/libGL.so* \
 	/usr/lib/libXss.so* \
+	/usr/lib/gtk-3*/*/* \
 	/usr/lib/gio/modules/* \
 	/usr/lib/gdk-pixbuf-*/*/*/* \
 	/usr/lib/alsa-lib/* \

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -10,6 +10,7 @@ LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bi
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
 VERSION=test
+echo "$VERSION" > ~/version
 
 # BUILD ARES
 git clone "$REPO" ./ares && (

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -77,7 +77,7 @@ echo "Generating AppImage..."
 	--no-history --no-create-timestamp \
 	--compression zstd:level=22 -S26 -B8 \
 	--header uruntime \
-	-i ./AppDir -o Citron-"$VERSION"-anylinux-"$ARCH".AppImage
+	-i ./AppDir -o ares-"$VERSION"-anylinux-"$ARCH".AppImage
 
 echo "Generating zsync file..."
 zsyncmake *.AppImage -u *.AppImage

--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -9,12 +9,12 @@ REPO="https://github.com/ares-emulator/ares"
 LIB4BN="https://raw.githubusercontent.com/VHSgunzo/sharun/refs/heads/main/lib4bin"
 URUNTIME="https://github.com/VHSgunzo/uruntime/releases/latest/download/uruntime-appimage-dwarfs-$ARCH"
 UPINFO="gh-releases-zsync|$(echo "$GITHUB_REPOSITORY" | tr '/' '|')|latest|*$ARCH.AppImage.zsync"
-VERSION=test
-echo "$VERSION" > ~/version
 
 # BUILD ARES
 git clone "$REPO" ./ares && (
 	cd ./ares
+	VERSION="$(git rev-parse --short HEAD)"
+	echo "$VERSION" > ~/version
 
 	# backport fix from aur package
 	sed -i \
@@ -33,6 +33,7 @@ git clone "$REPO" ./ares && (
 	cmake --install .
 )
 rm -rf ./ares
+VERSION="$(cat ~/version)"
 
 # NOW MAKE APPIMAGE
 mkdir ./AppDir

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -59,6 +59,14 @@ pacman -Syu --noconfirm \
 # Make librashader
 echo "Making extra dependencies..."
 echo "---------------------------------------------------------------"
+
+# fix nonsense
+sed -i 's|EUID == 0|EUID == 69|g' /usr/bin/makepkg
+mkdir -p /usr/local/bin
+cp /usr/bin/makepkg /usr/local/bin
+sed -i 's|-O2|-O3|; s|MAKEFLAGS=.*|MAKEFLAGS="-j$(nproc)"|; s|#MAKEFLAGS|MAKEFLAGS|' /etc/makepkg.conf
+cat /etc/makepkg.conf
+
 git clone "https://aur.archlinux.org/librashader.git" ./libreshader
 ( cd ./libreshader
   makepkg -f

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -10,7 +10,7 @@ else
 	PKG_TYPE='aarch64.pkg.tar.xz'
 fi
 
-LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
+LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-mini-$PKG_TYPE"
 LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
 OPUS_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/opus-nano-$PKG_TYPE"
 

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -49,6 +49,7 @@ pacman -Syu --noconfirm \
 	pulseaudio-alsa \
 	rust \
 	sdl2 \
+	sdl3 \
 	strace \
 	vulkan-driver \
 	vulkan-icd-loader \
@@ -77,8 +78,8 @@ cp /usr/bin/makepkg /usr/local/bin
 sed -i 's|-O2|-O3|; s|MAKEFLAGS=.*|MAKEFLAGS="-j$(nproc)"|; s|#MAKEFLAGS|MAKEFLAGS|' /etc/makepkg.conf
 cat /etc/makepkg.conf
 
-git clone "https://aur.archlinux.org/librashader.git" ./libreshader
-( cd ./libreshader
+git clone "https://aur.archlinux.org/librashader.git" ./librashader
+( cd ./librashader
   makepkg -f
   ls -la .
   pacman --noconfirm -U *.pkg.tar.*

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -47,6 +47,7 @@ pacman -Syu --noconfirm \
 	pkgconf \
 	pulseaudio \
 	pulseaudio-alsa \
+	rust \
 	sdl2 \
 	strace \
 	vulkan-driver \

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -34,7 +34,6 @@ pacman -Syu --noconfirm \
 	libdecor \
 	libgl \
 	libpulse \
-	librashader \
 	libretro-shaders \
 	libx11 \
 	libxrandr \

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -36,7 +36,6 @@ pacman -Syu --noconfirm \
 	libpulse \
 	librashader \
 	libretro-shaders \
-	libudev \
 	libx11 \
 	libxrandr \
 	libxss \
@@ -58,6 +57,16 @@ pacman -Syu --noconfirm \
 	zlib \
 	zsync
 
+# Make librashader
+echo "Making extra dependencies..."
+echo "---------------------------------------------------------------"
+git clone "https://aur.archlinux.org/librashader.git" ./libreshader
+( cd ./libreshader
+  makepkg -f
+  ls -la .
+  pacman --noconfirm -U *.pkg.tar.*
+)
+
 echo "Installing debloated pckages..."
 echo "---------------------------------------------------------------"
 wget --retry-connrefused --tries=30 "$LLVM_URL" -O   ./llvm-libs.pkg.tar.zst
@@ -69,5 +78,3 @@ rm -f ./*.pkg.tar.zst
 
 echo "All done!"
 echo "---------------------------------------------------------------"
-
-

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -57,6 +57,15 @@ pacman -Syu --noconfirm \
 	zlib \
 	zsync
 
+echo "Installing debloated pckages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$LLVM_URL" -O   ./llvm-libs.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$OPUS_URL" -O   ./opus-nano.pkg.tar.zst
+
+pacman -U --noconfirm ./*.pkg.tar.zst
+rm -f ./*.pkg.tar.zst
+
 # Make librashader
 echo "Making extra dependencies..."
 echo "---------------------------------------------------------------"
@@ -74,15 +83,6 @@ git clone "https://aur.archlinux.org/librashader.git" ./libreshader
   ls -la .
   pacman --noconfirm -U *.pkg.tar.*
 )
-
-echo "Installing debloated pckages..."
-echo "---------------------------------------------------------------"
-wget --retry-connrefused --tries=30 "$LLVM_URL" -O   ./llvm-libs.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2.pkg.tar.zst
-wget --retry-connrefused --tries=30 "$OPUS_URL" -O   ./opus-nano.pkg.tar.zst
-
-pacman -U --noconfirm ./*.pkg.tar.zst
-rm -f ./*.pkg.tar.zst
 
 echo "All done!"
 echo "---------------------------------------------------------------"

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -ex
+
+sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
+
+if [ "$(uname -m)" = 'x86_64' ]; then
+	PKG_TYPE='x86_64.pkg.tar.zst'
+else
+	PKG_TYPE='aarch64.pkg.tar.xz'
+fi
+
+LLVM_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/llvm-libs-nano-$PKG_TYPE"
+LIBXML_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/libxml2-iculess-$PKG_TYPE"
+OPUS_URL="https://github.com/pkgforge-dev/llvm-libs-debloated/releases/download/continuous/opus-nano-$PKG_TYPE"
+
+echo "Installing dependencies..."
+echo "---------------------------------------------------------------"
+pacman -Syu --noconfirm \
+	alsa-lib \
+	base-devel \
+	cairo \
+	cmake \
+	curl \
+	desktop-file-utils \
+	gcc-libs \
+	gdk-pixbuf2 \
+	git \
+	glib2 \
+	glibc \
+	gtk3 \
+	hicolor-icon-theme \
+	libao \
+	libdecor \
+	libgl \
+	libpulse \
+	librashader \
+	libretro-shaders \
+	libudev \
+	libx11 \
+	libxrandr \
+	libxss \
+	mesa \
+	ninja \
+	openal \
+	pango \
+	patchelf \
+	pipewire-audio \
+	pkgconf \
+	pulseaudio \
+	pulseaudio-alsa \
+	sdl2 \
+	strace \
+	vulkan-driver \
+	vulkan-icd-loader \
+	wget \
+	xorg-server-xvfb \
+	zlib \
+	zsync
+
+echo "Installing debloated pckages..."
+echo "---------------------------------------------------------------"
+wget --retry-connrefused --tries=30 "$LLVM_URL" -O   ./llvm-libs.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$LIBXML_URL" -O ./libxml2.pkg.tar.zst
+wget --retry-connrefused --tries=30 "$OPUS_URL" -O   ./opus-nano.pkg.tar.zst
+
+pacman -U --noconfirm ./*.pkg.tar.zst
+rm -f ./*.pkg.tar.zst
+
+echo "All done!"
+echo "---------------------------------------------------------------"
+
+


### PR DESCRIPTION
[TEST CAREFULLY](https://github.com/Samueru-sama/ares-emu-appimage/releases/tag/v143), since I have no idea how to use this 😆

My limited testing has been making sure that the app opens in alpine linux and ubuntu 20.04, it also seems to detect Opengl. 

Something that worries me is that I noticed the `ares` binary has a string for `/usr/lib/librashader.so`.

![image](https://github.com/user-attachments/assets/51e1701c-85db-4276-a256-a259792f7657)

This usually means the bin is hardcoded to try to dlopen the lib in that location, but I don't know when that happens, it doesn't try to load that lib at all after checking the strace output during my tests. 

There are multiple ways to fix that issue, but I would first need to be able to know how to open that lib. 

Another issue is that right now this is building off the latest commit, I have no idea how to do what you were doing in the CI to switch to stable releases, since I normally checkout a tag instead, which in this case `git describe --tags` only shows `nightly` 🧐