### PR TITLE
simplify appimage creation

### DIFF
--- a/ares-appimage.sh
+++ b/ares-appimage.sh
@@ -44,9 +44,8 @@ rm -rf ./ares
 [ -n "$VERSION" ] && echo "$VERSION" > ~/version
 
 # NOW MAKE APPIMAGE
-URUNTIME="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/uruntime2appimage.sh"
 SHARUN="https://raw.githubusercontent.com/pkgforge-dev/Anylinux-AppImages/refs/heads/main/useful-tools/quick-sharun.sh"
-
+export OUTPUT_APPIMAGE=1
 export ADD_HOOKS="self-updater.bg.hook"
 export OUTNAME=ares-"$VERSION"-anylinux-"$ARCH".AppImage
 export DESKTOP=/usr/share/applications/ares.desktop
@@ -58,11 +57,6 @@ export DEPLOY_PIPEWIRE=1
 wget --retry-connrefused --tries=30 "$SHARUN" -O ./quick-sharun
 chmod +x ./quick-sharun
 ./quick-sharun /usr/bin/ares /usr/bin/sourcery
-
-# turn appdir into appimage
-wget --retry-connrefused --tries=30 "$URUNTIME" -O ./uruntime2appimage
-chmod +x ./uruntime2appimage
-./uruntime2appimage
 
 mkdir -p ./dist
 mv -v ./*.AppImage* ./dist


### PR DESCRIPTION
`OUTPUT_APPIMAGE` makes `quick-sharun` download and run `uruntime2appimage`.