### PR TITLE
chore: prepare for ares v149

### DIFF
--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -14,6 +14,7 @@ pacman -Syu --noconfirm \
 	git                    \
 	gtk3                   \
 	libdecor               \
+	libpulse               \
 	libretro-shaders-slang \
 	libx11                 \
 	libxrandr              \
@@ -21,6 +22,8 @@ pacman -Syu --noconfirm \
 	ninja                  \
 	pipewire-audio         \
 	pkgconf                \
+	pulseaudio             \
+	pulseaudio-alsa        \
 	rust                   \
 	sdl3                   \
 	wget                   \

--- a/get-dependencies.sh
+++ b/get-dependencies.sh
@@ -9,23 +9,18 @@ pacman -Syu --noconfirm \
 	base-devel             \
 	cmake                  \
 	ccache                 \
+	clang                  \
 	curl                   \
-	gcc-libs               \
 	git                    \
 	gtk3                   \
-	libao                  \
 	libdecor               \
-	libpulse               \
 	libretro-shaders-slang \
 	libx11                 \
 	libxrandr              \
 	libxss                 \
 	ninja                  \
-	openal                 \
 	pipewire-audio         \
 	pkgconf                \
-	pulseaudio             \
-	pulseaudio-alsa        \
 	rust                   \
 	sdl3                   \
 	wget                   \


### PR DESCRIPTION
With ares v149 and the actual nightly only sdl is used as a audio driver. Therefor all other audio drivers can be removed.